### PR TITLE
fix: flow constructor

### DIFF
--- a/contracts/dataFlow/FixedPriceFlow.sol
+++ b/contracts/dataFlow/FixedPriceFlow.sol
@@ -7,9 +7,9 @@ contract FixedPriceFlow is Flow {
     error NotEnoughFee(uint price, uint amount, uint paid);
 
     // reserved storage slots for base contract upgrade in future
-    uint[49] private __gap;
+    uint[46] private __gap;
 
-    constructor(uint blocksPerEpoch_, uint deployDelay_) Flow(blocksPerEpoch_, deployDelay_) {}
+    constructor(uint deployDelay_) Flow(deployDelay_) {}
 
     function _beforeSubmit(uint sectors) internal override {
         uint price = FixedPrice(market).pricePerSector();

--- a/contracts/dataFlow/Flow.sol
+++ b/contracts/dataFlow/Flow.sol
@@ -174,7 +174,7 @@ contract Flow is IFlow, PauseControl, ZgInitializable {
         IMarket(market).chargeFee(previousLength, chargedLength, paddedLength);
     }
 
-    function _makeContext() internal returns (bool) {
+    function _makeContext() internal whenNotPaused returns (bool) {
         uint nextEpochStart;
         unchecked {
             nextEpochStart = firstBlock + (epoch + 1) * blocksPerEpoch;

--- a/contracts/utils/DigestHistory.sol
+++ b/contracts/utils/DigestHistory.sol
@@ -15,7 +15,7 @@ contract DigestHistory is IDigestHistory, Ownable {
         nextIndex = 0;
     }
 
-    function insert(bytes32 data) external returns (uint) {
+    function insert(bytes32 data) external onlyOwner returns (uint) {
         uint index = nextIndex;
         uint slot = nextIndex % digests.length;
         digests[slot] = data;

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -22,6 +22,7 @@ const userConfig: HttpNetworkUserConfig = {
 
 import "./src/tasks/access";
 import "./src/tasks/codesize";
+import "./src/tasks/flow";
 import "./src/tasks/upgrade";
 
 const config: HardhatUserConfig = {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,3 +1,4 @@
+import { ZeroAddress } from "ethers";
 import { ZerogContractConfigs } from "./networks/zerog_contract_config";
 import { ZerogTestnetContractConfigsStandard } from "./networks/zerog_testnet_contract_config_standard";
 import { ZerogTestnetContractConfigsTurbo } from "./networks/zerog_testnet_contract_config_turbo";
@@ -12,6 +13,8 @@ export interface NetworkConfigs {
     mineConfigs: MineConfigs;
     // This variable determines how often the `makeContext` function needs to be called within each mining cycle, known as an Epoch. If this function is not called over several epochs, it may cause issues. By default, this value is set very high, meaning that the contract will not generate mining tasks. For mining tests, adjust it to a suitable size (recommended block count per hour).
     blocksPerEpoch: number;
+    firstBlock: number;
+    rootHistory: string;
     // Upon enabling the economic model, this controls the data storage validity period and the reward release cycle. The annual storage cost per GB is a constant in the contract named `ANNUAL_ZGS_TOKENS_PER_GB`.
     lifetimeMonth: number;
     flowDeployDelay: number;
@@ -24,6 +27,8 @@ export const DefaultConfig: NetworkConfigs = {
         initDifficulty: 30000,
     },
     blocksPerEpoch: 1000000000,
+    firstBlock: 0,
+    rootHistory: ZeroAddress,
     lifetimeMonth: 3,
     flowDeployDelay: 0,
     unitPrice: 1,

--- a/src/deploy/deploy_chunk_linear_reward.ts
+++ b/src/deploy/deploy_chunk_linear_reward.ts
@@ -1,7 +1,7 @@
 import { DeployFunction } from "hardhat-deploy/types";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
-import { CONTRACTS, deployInBeaconProxy } from "../utils/utils";
 import { getConstructorArgs } from "../utils/constructor_args";
+import { CONTRACTS, deployInBeaconProxy } from "../utils/utils";
 
 const deploy: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     await deployInBeaconProxy(

--- a/src/deploy/deploy_fixed_price_flow.ts
+++ b/src/deploy/deploy_fixed_price_flow.ts
@@ -1,7 +1,7 @@
 import { DeployFunction } from "hardhat-deploy/types";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
-import { CONTRACTS, deployInBeaconProxy } from "../utils/utils";
 import { getConstructorArgs } from "../utils/constructor_args";
+import { CONTRACTS, deployInBeaconProxy } from "../utils/utils";
 
 const deploy: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     await deployInBeaconProxy(

--- a/src/deploy/deploy_flow.ts
+++ b/src/deploy/deploy_flow.ts
@@ -1,7 +1,7 @@
 import { DeployFunction } from "hardhat-deploy/types";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
-import { CONTRACTS, deployInBeaconProxy } from "../utils/utils";
 import { getConstructorArgs } from "../utils/constructor_args";
+import { CONTRACTS, deployInBeaconProxy } from "../utils/utils";
 
 const deploy: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     await deployInBeaconProxy(hre, CONTRACTS.Flow, getConstructorArgs(hre.network.name, CONTRACTS.Flow.name));

--- a/src/deploy/deploy_market_enabled_initialization.ts
+++ b/src/deploy/deploy_market_enabled_initialization.ts
@@ -44,7 +44,7 @@ const deploy: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
 
     console.log(`initializing fixed price flow..`);
     if (!(await fixedPriceFlow_.initialized())) {
-        await (await fixedPriceFlow_.initialize(marketAddress)).wait();
+        await (await fixedPriceFlow_.initialize(marketAddress, config.blocksPerEpoch)).wait();
     }
     console.log(`all contract initialized.`);
 };

--- a/src/deploy/deploy_no_market_initialization.ts
+++ b/src/deploy/deploy_no_market_initialization.ts
@@ -28,7 +28,7 @@ const deploy: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
 
     console.log(`initializing flow..`);
     if (!(await flow_.initialized())) {
-        await (await flow_.initialize(await dummyMarket_.getAddress())).wait();
+        await (await flow_.initialize(await dummyMarket_.getAddress(), config.blocksPerEpoch)).wait();
     }
     console.log(`all contract initialized.`);
 };

--- a/src/deploy/deploy_one_pool_reward.ts
+++ b/src/deploy/deploy_one_pool_reward.ts
@@ -1,7 +1,7 @@
 import { DeployFunction } from "hardhat-deploy/types";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
-import { CONTRACTS, deployInBeaconProxy } from "../utils/utils";
 import { getConstructorArgs } from "../utils/constructor_args";
+import { CONTRACTS, deployInBeaconProxy } from "../utils/utils";
 
 const deploy: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     await deployInBeaconProxy(

--- a/src/deploy/deploy_pora_mine.ts
+++ b/src/deploy/deploy_pora_mine.ts
@@ -1,7 +1,7 @@
 import { DeployFunction } from "hardhat-deploy/types";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
-import { CONTRACTS, deployInBeaconProxy } from "../utils/utils";
 import { getConstructorArgs } from "../utils/constructor_args";
+import { CONTRACTS, deployInBeaconProxy } from "../utils/utils";
 
 const deploy: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     await deployInBeaconProxy(hre, CONTRACTS.PoraMine, getConstructorArgs(hre.network.name, CONTRACTS.PoraMine.name));

--- a/src/deploy/deploy_pora_mine_test.ts
+++ b/src/deploy/deploy_pora_mine_test.ts
@@ -1,7 +1,7 @@
 import { DeployFunction } from "hardhat-deploy/types";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
-import { CONTRACTS, deployInBeaconProxy } from "../utils/utils";
 import { getConstructorArgs } from "../utils/constructor_args";
+import { CONTRACTS, deployInBeaconProxy } from "../utils/utils";
 
 const deploy: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     await deployInBeaconProxy(

--- a/src/networks/zerog_contract_config.ts
+++ b/src/networks/zerog_contract_config.ts
@@ -1,3 +1,4 @@
+import { ZeroAddress } from "ethers";
 import { NetworkConfigs } from "../config";
 
 export const ZerogContractConfigs: NetworkConfigs = {
@@ -6,6 +7,8 @@ export const ZerogContractConfigs: NetworkConfigs = {
         initDifficulty: 180000,
     },
     blocksPerEpoch: 1200,
+    firstBlock: 0,
+    rootHistory: ZeroAddress,
     lifetimeMonth: 3,
     flowDeployDelay: 0,
     unitPrice: 1,

--- a/src/networks/zerog_testnet_contract_config_standard.ts
+++ b/src/networks/zerog_testnet_contract_config_standard.ts
@@ -1,3 +1,4 @@
+import { ZeroAddress } from "ethers";
 import { NetworkConfigs } from "../config";
 
 export const ZerogTestnetContractConfigsStandard: NetworkConfigs = {
@@ -6,6 +7,8 @@ export const ZerogTestnetContractConfigsStandard: NetworkConfigs = {
         initDifficulty: 180000,
     },
     blocksPerEpoch: 200,
+    firstBlock: 594994,
+    rootHistory: ZeroAddress,
     lifetimeMonth: 3,
     flowDeployDelay: 0,
     unitPrice: 1,

--- a/src/networks/zerog_testnet_contract_config_turbo.ts
+++ b/src/networks/zerog_testnet_contract_config_turbo.ts
@@ -1,3 +1,4 @@
+import { ZeroAddress } from "ethers";
 import { NetworkConfigs } from "../config";
 
 export const ZerogTestnetContractConfigsTurbo: NetworkConfigs = {
@@ -6,6 +7,8 @@ export const ZerogTestnetContractConfigsTurbo: NetworkConfigs = {
         initDifficulty: 180000,
     },
     blocksPerEpoch: 200,
+    firstBlock: 595043,
+    rootHistory: ZeroAddress,
     lifetimeMonth: 3,
     flowDeployDelay: 0,
     unitPrice: 10,

--- a/src/tasks/flow.ts
+++ b/src/tasks/flow.ts
@@ -33,3 +33,17 @@ task("flow:unpause", "unpause contract").setAction(async (_, hre) => {
     await (await flow.unpause()).wait();
     console.log(`done.`);
 });
+
+task("flow:updatecontext", "update context to latest").setAction(async (_, hre) => {
+    const flow = await getTypedContract(hre, CONTRACTS.FixedPriceFlow);
+    for (;;) {
+        const before = await flow.epoch();
+        await (await flow.makeContextFixedTimes(100)).wait();
+        const after = await flow.epoch();
+        if (after === before) {
+            break;
+        }
+        console.log(`updated epoch to ${after}.`);
+    }
+    console.log(`done.`);
+});

--- a/src/tasks/flow.ts
+++ b/src/tasks/flow.ts
@@ -1,0 +1,35 @@
+import { task } from "hardhat/config";
+import { getConfig } from "../config";
+import { CONTRACTS, getTypedContract } from "../utils/utils";
+
+task("flow:show", "show contract params").setAction(async (_, hre) => {
+    const flow = await getTypedContract(hre, CONTRACTS.FixedPriceFlow);
+    // const signer = await hre.ethers.getSigner((await hre.getNamedAccounts()).deployer);
+    // testnet turbo first impl
+    // const flow = CONTRACTS.FixedPriceFlow.factory.connect("0x61450afb8F99AB3D614a45cb563C61f59d9DD026", signer);
+    // testnet standard first impl
+    // const flow = CONTRACTS.FixedPriceFlow.factory.connect("0x1F7A30Cd62c4132B6C521B8F79e7aE0046A4F307", signer);
+    console.log(await flow.getContext());
+    console.log(await flow.blocksPerEpoch());
+    console.log(await flow.firstBlock());
+    console.log(await flow.rootHistory());
+});
+
+task("flow:setparams", "set contract params").setAction(async (_, hre) => {
+    const flow = await getTypedContract(hre, CONTRACTS.FixedPriceFlow);
+    const config = getConfig(hre.network.name);
+    await (await flow.setParams(config.blocksPerEpoch, config.firstBlock, config.rootHistory)).wait();
+    console.log(`done.`);
+});
+
+task("flow:pause", "pause contract").setAction(async (_, hre) => {
+    const flow = await getTypedContract(hre, CONTRACTS.FixedPriceFlow);
+    await (await flow.pause()).wait();
+    console.log(`done.`);
+});
+
+task("flow:unpause", "unpause contract").setAction(async (_, hre) => {
+    const flow = await getTypedContract(hre, CONTRACTS.FixedPriceFlow);
+    await (await flow.unpause()).wait();
+    console.log(`done.`);
+});

--- a/src/utils/constructor_args.ts
+++ b/src/utils/constructor_args.ts
@@ -10,11 +10,11 @@ export function getConstructorArgs(network: string, name: string): unknown[] {
             break;
         }
         case CONTRACTS.FixedPriceFlow.name: {
-            args = [config.blocksPerEpoch, config.flowDeployDelay];
+            args = [config.flowDeployDelay];
             break;
         }
         case CONTRACTS.Flow.name: {
-            args = [config.blocksPerEpoch, config.flowDeployDelay];
+            args = [config.flowDeployDelay];
             break;
         }
         case CONTRACTS.OnePoolReward.name: {


### PR DESCRIPTION
- Replace immutable states `rootHistory`, `blocksPerEpoch`, `firstBlock` with mutable states.
- Move the constructor logic into initializer, add `setParams()` to fix current deployed contracts.
- Add `whenNotPaused` to `_makeContext()`.
- Add `onlyOwner` modifier for `insert()` of `DigestHistory` contract.
- Update network configurations and scripts.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/0glabs/0g-storage-contracts/37)
<!-- Reviewable:end -->
