### PR TITLE
Implement the next PoRA mine specification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:
       - main
+      - next_mine_spec
 
 jobs:
   build:

--- a/contracts/miner/Mine.sol
+++ b/contracts/miner/Mine.sol
@@ -16,6 +16,7 @@ import "../interfaces/IDigestHistory.sol";
 
 import "./RecallRange.sol";
 import "./MineLib.sol";
+import "./WorkerContext.sol";
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
@@ -61,6 +62,7 @@ contract PoraMine is ZgInitializable, AccessControlEnumerable {
 
     // Updated configurable parameters
     uint public minDifficulty;
+    uint public nSubtasks;
 
     event NewMinerId(bytes32 indexed minerId, address indexed beneficiary);
     event UpdateMinerId(bytes32 indexed minerId, address indexed from, address indexed to);
@@ -87,6 +89,7 @@ contract PoraMine is ZgInitializable, AccessControlEnumerable {
         targetSubmissionsNextEpoch = 10;
         difficultyAdjustRatio = 20;
         maxShards = 32;
+        nSubtasks = 1;
     }
 
     function poraVersion() external pure returns (uint64) {
@@ -101,15 +104,8 @@ contract PoraMine is ZgInitializable, AccessControlEnumerable {
 
         // Step 2: maintain context
         MineContext memory context = IFlow(flow).makeContextWithResult();
-        require(context.epoch >= lastMinedEpoch, "Internal error: epoch number decrease");
-        if (context.epoch > lastMinedEpoch && lastMinedEpoch > 0) {
-            if (currentSubmissions < targetSubmissions) {
-                // Not enough submissions in the last epoch
-                _adjustDifficultyOnIncompleteEpoch();
-            }
-            currentSubmissions = 0;
-            targetSubmissions = targetSubmissionsNextEpoch;
-        }
+        _updateMineEpochWhenNeeded(context);
+        bytes32 subtaskDigest = getSubtaskDigest(context, answer.minerId);
 
         // Step 3: basic check for submission
         basicCheck(answer, context);
@@ -129,7 +125,7 @@ contract PoraMine is ZgInitializable, AccessControlEnumerable {
         delete unsealedData;
 
         // Step 5: compute PoRA hash
-        bytes32 poraOutput = pora(answer);
+        bytes32 poraOutput = pora(answer, subtaskDigest);
         uint scaleX64 = answer.range.targetScaleX64(context.flowLength);
         // scaleX64 >= 2^64, so there is no overflow
         require(uint(poraOutput) <= (poraTarget / scaleX64) << 64, "Do not reach target quality");
@@ -147,21 +143,13 @@ contract PoraMine is ZgInitializable, AccessControlEnumerable {
         emit NewSubmission(context.epoch, answer.minerId, currentSubmissions, answer.recallPosition);
         lastMinedEpoch = context.epoch;
         currentSubmissions += 1;
-        if (currentSubmissions < targetSubmissions) {
-            return;
-        }
-
-        // Step 8: adjust quality
-        if (!fixedDifficulty) {
-            _adjustDifficulty(context);
-        }
     }
 
     function basicCheck(MineLib.PoraAnswer memory answer, MineContext memory context) public view {
         // Check basic field
         require(context.digest == answer.contextDigest, "Inconsistent mining digest");
         require(context.digest != EMPTY_HASH, "Empty digest can not mine");
-        require(currentSubmissions < targetSubmissions, "Epoch has enough submissions");
+        require(currentSubmissions < 2 * targetSubmissions, "Epoch has enough submissions");
 
         // Check validity of recall range
         uint maxLength = (context.flowLength / SECTORS_PER_LOAD) * SECTORS_PER_LOAD;
@@ -176,10 +164,10 @@ contract PoraMine is ZgInitializable, AccessControlEnumerable {
         );
     }
 
-    function pora(MineLib.PoraAnswer memory answer) public view returns (bytes32) {
+    function pora(MineLib.PoraAnswer memory answer, bytes32 subtaskDigest) public view returns (bytes32) {
         require(answer.minerId != bytes32(0x0), "Miner ID cannot be empty");
 
-        bytes32[4] memory seedInput = [answer.minerId, answer.nonce, answer.contextDigest, answer.range.digest()];
+        bytes32[4] memory seedInput = [answer.minerId, answer.nonce, subtaskDigest, answer.range.digest()];
 
         bytes32[2] memory padSeed = Blake2b.blake2b(seedInput);
 
@@ -197,6 +185,25 @@ contract PoraMine is ZgInitializable, AccessControlEnumerable {
         return MineLib.computePoraHash(answer.sealOffset, padSeed, mixedData);
     }
 
+    function _updateMineEpochWhenNeeded(MineContext memory context) internal {
+        require(context.epoch >= lastMinedEpoch, "Internal error: epoch number decrease");
+
+        if (context.epoch > lastMinedEpoch && lastMinedEpoch > 0) {
+            _adjustDifficultyOnNewEpoch();
+            currentSubmissions = 0;
+            targetSubmissions = targetSubmissionsNextEpoch;
+        }
+    }
+
+    function getSubtaskDigest(MineContext memory context, bytes32 minerId) public view returns (bytes32) {
+        uint subtaskIdx = uint(keccak256(abi.encode(context.digest, minerId))) % nSubtasks;
+        uint subtaskMineStart = context.mineStart + subtaskIdx;
+        require(block.number > subtaskMineStart, "Earlier than expected subtask start block.");
+        require(block.number - subtaskMineStart <= targetMineBlocks, "Mine deadline exceed");
+
+        return keccak256(abi.encode(context.digest, blockhash(subtaskMineStart)));
+    }
+
     function requestMinerId(address beneficiary, uint64 seed) public {
         bytes32 minerId = keccak256(abi.encodePacked(blockhash(block.number - 1), msg.sender, seed));
         require(beneficiaries[minerId] == address(0), "MinerId has registered");
@@ -210,21 +217,27 @@ contract PoraMine is ZgInitializable, AccessControlEnumerable {
         emit UpdateMinerId(minerId, msg.sender, to);
     }
 
-    function _adjustDifficulty(MineContext memory context) internal {
-        uint miningBlocks = block.number - context.mineStart;
-
+    function _adjustDifficultyOnNewEpoch() internal {
         // Remove least significant 16 bits to avoid overflow
-        uint scaledTarget = poraTarget >> 16;
-        uint scaledExpected = Math.mulDiv(scaledTarget, miningBlocks, targetMineBlocks);
+        uint scaledExpected;
+        if (currentSubmissions > 0) {
+            uint scaledTarget = poraTarget >> 16;
+            scaledExpected = Math.mulDiv(scaledTarget, targetMineBlocks, currentSubmissions);
+        } else {
+            scaledExpected = type(uint).max >> 16;    
+        }
 
         _adjustDifficultyInner(scaledExpected);
     }
 
-    function _adjustDifficultyOnIncompleteEpoch() internal {
+    function _adjustDifficultyOnSkippedEpoch() internal {
         _adjustDifficultyInner(type(uint).max >> 16);
     }
 
     function _adjustDifficultyInner(uint scaledExpected) internal {
+        if(fixedDifficulty) {
+            return;
+        }
         uint scaledTarget = poraTarget >> 16;
 
         uint n = difficultyAdjustRatio;
@@ -260,6 +273,7 @@ contract PoraMine is ZgInitializable, AccessControlEnumerable {
     }
 
     function setTargetMineBlocks(uint targetMineBlocks_) external onlyRole(PARAMS_ADMIN_ROLE) {
+        require(targetMineBlocks_ <= 256, "target mine block must <= 256");
         targetMineBlocks = targetMineBlocks_;
     }
 
@@ -289,8 +303,39 @@ contract PoraMine is ZgInitializable, AccessControlEnumerable {
         }
     }
 
+    function setNumSubtasks(uint nSubtasks_) external onlyRole(PARAMS_ADMIN_ROLE) {
+        require(nSubtasks_ > 0, "Number of subtasks cannot be zero");
+        require(nSubtasks_ < IFlow(flow).blocksPerEpoch(), "Number of subtasks must be less than blocks per epoch");
+        nSubtasks = nSubtasks_;
+    }
+
     function canSubmit() external returns (bool) {
         MineContext memory context = IFlow(flow).makeContextWithResult();
-        return context.epoch > lastMinedEpoch || currentSubmissions < targetSubmissions;
+        return context.epoch > lastMinedEpoch || currentSubmissions < targetSubmissions * 2;
+    }
+
+    function computeWorkerContext(bytes32 minerId) external returns (WorkerContext memory answer) {
+        require(minerId != bytes32(0), "MinerId cannot be zero");
+        address beneficiary = beneficiaries[minerId];
+        require(beneficiary != address(0), "MinerId does not registered");
+
+        answer.maxShards = maxShards;
+        answer.context = IFlow(flow).makeContextWithResult();
+
+        uint subtaskIdx = uint(keccak256(abi.encode(answer.context.digest, minerId))) % nSubtasks;
+        uint subtaskMineStart = answer.context.mineStart + subtaskIdx;
+        if (block.number <= subtaskMineStart || block.number - subtaskMineStart > targetMineBlocks) {
+            return answer;
+        }
+        
+        answer.subtaskDigest = keccak256(abi.encode(answer.context.digest, blockhash(subtaskMineStart)));
+
+        if (answer.context.epoch > lastMinedEpoch) {
+            _updateMineEpochWhenNeeded(answer.context);
+        }
+        
+        if (currentSubmissions < targetSubmissions * 2) {
+            answer.poraTarget = poraTarget;
+        }
     }
 }

--- a/contracts/miner/Mine.sol
+++ b/contracts/miner/Mine.sol
@@ -37,7 +37,7 @@ contract PoraMine is ZgInitializable, AccessControlEnumerable {
     uint private constant NO_DATA_PROOF = 0x2;
     uint private constant FIXED_DIFFICULTY = 0x4;
 
-    uint64 private constant PORA_VERSION = 0;
+    uint64 private constant PORA_VERSION = 1;
 
     // Deferred initializd fields
     address public flow;

--- a/contracts/miner/WorkerContext.sol
+++ b/contracts/miner/WorkerContext.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity >=0.8.0 <0.9.0;
+
+import "../interfaces/IFlow.sol";
+
+struct WorkerContext {
+    MineContext context;
+    uint poraTarget;
+    bytes32 subtaskDigest;
+    uint64 maxShards;
+}

--- a/contracts/test/PoraMineTest.sol
+++ b/contracts/test/PoraMineTest.sol
@@ -29,12 +29,12 @@ contract PoraMineTest is PoraMine {
         return MineLib.recoverMerkleRoot(answer, unsealedData);
     }
 
-    function testAll(MineLib.PoraAnswer memory answer) external view {
+    function testAll(MineLib.PoraAnswer memory answer, bytes32 subtaskDigest) external view {
         bytes32[UNITS_PER_SEAL] memory unsealedData = MineLib.unseal(answer);
 
         MineLib.recoverMerkleRoot(answer, unsealedData);
         delete unsealedData;
 
-        pora(answer);
+        pora(answer, subtaskDigest);
     }
 }

--- a/contracts/utils/ZgsSpec.sol
+++ b/contracts/utils/ZgsSpec.sol
@@ -10,7 +10,7 @@ uint constant MAX_MINING_LENGTH = (8 * TB) / BYTES_PER_SECTOR;
 
 uint constant BYTES_PER_SECTOR = 256;
 uint constant BYTES_PER_SEAL = 4 * KB;
-uint constant BYTES_PER_PAD = 64 * KB;
+uint constant BYTES_PER_PAD = 16 * KB;
 uint constant BYTES_PER_LOAD = 256 * KB;
 uint constant BYTES_PER_PRICE = 8 * GB;
 uint constant BYTES_PER_SEGMENT = 256 * KB;

--- a/test/mine.spec.ts
+++ b/test/mine.spec.ts
@@ -466,7 +466,7 @@ async function makeScratchPad(
     const padSeed = input;
 
     for (let i = 0; i < BHASHES_PER_PAD; i++) {
-        answer[i] = await scratchPadItemHash(input);
+        answer[i] = await scratchPadItemHashV2(input);
         input = answer[i];
     }
 

--- a/test/utils/params.ts
+++ b/test/utils/params.ts
@@ -1,6 +1,6 @@
 const BYTES_PER_SECTOR = 256;
 const BYTES_PER_SEAL = 4 * 1024; // 4 KB
-const BYTES_PER_PAD = 64 * 1024; // 64 KB
+const BYTES_PER_PAD = 16 * 1024; // 16 KB
 const BYTES_PER_LOAD = 256 * 1024; // 256 KB
 const BYTES_PER_PRICE = 8 * 1024 * 1024 * 1024; // 8 GB
 const BYTES_PER_SEGMENT = 256 * 1024; // 256 KB


### PR DESCRIPTION
This PR implements the new version of the PoRA specification, designed to support more mining result submissions within the given blockchain block gas limit.

The following content assumes you are already familiar with the previous version of the PoRA mining algorithm, and will focus mainly on the changes introduced. If you're not familiar with it, I recommend reading the PoRA mining algorithm documentation first.

## Overview

### Improved Scratch Pad Hashing Algorithm

The algorithm for hashing each round of the scratch pad has been updated to optimize gas usage in the EVM, while retaining the same CPU cost. This change will reduce the overall cost of running the PoRA verification protocol on the EVM and support more frequent mine submissions on the blockchain.

### Introduction of Subtasks
A new concept of "subtasks" has been introduced to better distribute the workload among miners.

- **Subtask Assignment**: When the parameter `nSubtask` is greater than 1, miners are randomly assigned to different subtasks based on the mining context and their miner ID.
- **Start Mining Blocks**: Each subtask is associated with a different starting block within each mining epoch. The hash of the starting block will be used as input for the PoRA scratchpad seed calculation. So miners must wait for their assigned starting block to begin mining. This is designed to spread out the submission times across the network.
- **Goal**: The primary motivation behind this change is to reduce the peak pressure on blockchain transactions by distributing mining results more evenly over time.

### Updated Mining and Difficulty Adjustment Rules
The mining and difficulty adjustment rules have been modified to allow more flexibility in result submissions.

In the previous design, each mining epoch had a fixed number of submissions. Difficulty was adjusted based on the comparison between the actual time taken to reach the target number of submissions and the expected time.

In the new design, each miner can now submit mining results freely within the `targetMineBlocks` range, starting from their assigned block. The difficulty is adjusted based on the actual number of submissions in the whole mining epoch compared to the expected number. 

## Scratch Pad Calculation Process

### Review: Scratch Pad Calculation
The calculation process for the scratch pad begins with a 64-byte scratchpad seed. A scratch pad generation function, denoted as `h`, takes a 64-byte input and produces a 64-byte output. This function is repeatedly applied to the 64-byte content, and its outputs are concatenated to form the scratch pad, continuing until the total length of the scratch pad meets the required `SCRATCHPAD_SIZE`.

### Change in SCRATCHPAD_SIZE
The size has been reduced from 64KB to 16KB, as the new generation function incurs approximately four times the CPU cost of the previous one.


### Modification of the Generation Function
- **Old Function**:  
  The previous function `h(x)` was defined as `blake2b512(x)`.

- **New Function**:  
  The new function `h(x)` views `x` as a tuple of two 32-byte values `(a, b)`, then computes:
  - `c = keccak256(a·b)`
  - `d = keccak256(c·b)`
  The output of the function is the concatenation of `c` and `d` (`c·d`), where `·` represents the concatenation of byte strings.

## Subtask Design for Workload Distribution

Subtasks are designed to distribute the workload among miners. The contract admin sets the `nSubtask` parameter.

### Subtask Assignment

- At the start of each mining epoch, the system determines the mining context, which includes the `contextStartBlockNumber` and the `contextDigest`.
- For the miner with `minerId`, it then calculates `keccak256(contextDigest, minerId)`, treats the output as a big-endian integer, and takes the result modulo `nSubtask` to assign a subtask ID (`subtaskId`).
- The start mining block for this miner is calculated as `contextStartBlockNumber + subtaskId`.

### Changes in Scratchpad Seed Calculation

The scratchpad seed was generated using the `blake2b512` function, with bytes 64 to 95 of the input as `contextDigest`. In the new design, `subtaskDigest` replaces `contextDigest`, defined as `keccak256(contextDigest, <block hash of start mining block>)`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/0glabs/0g-storage-contracts/48)
<!-- Reviewable:end -->
